### PR TITLE
fix: render real date in weekly discovery issue title

### DIFF
--- a/.github/workflows/discover.yml
+++ b/.github/workflows/discover.yml
@@ -49,11 +49,12 @@ jobs:
 
           COUNT=$(grep -c '^- \[' /tmp/discoveries.md || true)
           echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+          echo "date=$(date +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
 
       - name: Create issue if discoveries found
         if: success() && steps.search.outputs.count != '0'
         uses: peter-evans/create-issue-from-file@v6
         with:
-          title: "Weekly Discovery: New repos ($(date +%Y-%m-%d))"
+          title: "Weekly Discovery: New repos (${{ steps.search.outputs.date }})"
           content-filepath: /tmp/discoveries.md
           labels: discovery, triage


### PR DESCRIPTION
## Problem

The Discover workflow opens issues titled literally `Weekly Discovery: New repos ($(date +%Y-%m-%d))` (see #9). The `$(date ...)` is a `with:` input to `peter-evans/create-issue-from-file` (a JS action), not a shell `run:` step, so GitHub never shell-evaluates it. Only `${{ }}` expressions expand in `with:` values. The issue *body* shows the date correctly because it is built in a `run:` block.

## Fix

- Emit the date as a step output in the `search` step (reuses the existing `$GITHUB_OUTPUT` pattern next to `count`).
- Reference `${{ steps.search.outputs.date }}` in the title.

Next issue title will render e.g. `Weekly Discovery: New repos (2026-06-19)`.

## Verify

Trigger via `workflow_dispatch` from the Actions tab and confirm the new issue title shows a real date.