### PR TITLE
feat: add tfpolicy to Policy Engines

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -57,6 +57,7 @@ Maintained by [Anton Babenko](https://github.com/antonbabenko), creator of [terr
 
 - [Open Policy Agent (OPA)](https://www.openpolicyagent.org/) - General-purpose policy engine using Rego language, CNCF graduated project with extensive Terraform integration via Conftest and terraform-plan evaluation.
 - [HashiCorp Sentinel](https://www.hashicorp.com/sentinel) - Policy-as-code framework embedded in Terraform Cloud/Enterprise for enforcing compliance rules on runs. 💲
+- [Terraform policy (tfpolicy)](https://developer.hashicorp.com/terraform/policy) - HCL-based policy framework from HashiCorp that evaluates rules at three points in a run: provider and module install, plan, and apply. Ships a local CLI for testing policies before they reach HCP Terraform. Public beta. 💲
 - [Cloud Custodian](https://cloudcustodian.io/) - Rules engine for cloud resource management with Terraform plan evaluation and runtime policy enforcement. CNCF incubating project.
 
 ## IaC Security Scanners
@@ -222,7 +223,7 @@ Maintained by [Anton Babenko](https://github.com/antonbabenko), creator of [terr
 
 *Remote execution platforms for Terraform and OpenTofu with policy enforcement built into the run lifecycle. Unlike the CI/CD integrations below, these replace or wrap your pipeline entirely.*
 
-- [HCP Terraform and Terraform Enterprise](https://developer.hashicorp.com/terraform/cloud-docs) - HashiCorp's Terraform execution platform with native Sentinel and OPA policy enforcement on runs, audit logging, and team access controls, available as cloud-hosted (HCP Terraform) or self-hosted (Terraform Enterprise). 💲 🆓
+- [HCP Terraform and Terraform Enterprise](https://developer.hashicorp.com/terraform/cloud-docs) - HashiCorp's Terraform execution platform with native Sentinel, OPA, and Terraform policy enforcement on runs, audit logging, and team access controls, available as cloud-hosted (HCP Terraform) or self-hosted (Terraform Enterprise). 💲 🆓
 - [Spacelift](https://spacelift.io/) - Terraform and OpenTofu automation platform with built-in OPA policy evaluation on plans, drift detection, and custom policy frameworks. 💲 🆓
 - [env0](https://www.env0.com/) - Terraform and OpenTofu automation platform with OPA and Checkov policy integration, cost governance, and environment lifecycle management. 💲 🆓
 - [Scalr](https://scalr.com/) - Terraform automation platform with OPA policy enforcement and hierarchical policy inheritance across organizations, accounts, and environments. 💲 🆓


### PR DESCRIPTION
## What

Adds [Terraform policy (tfpolicy)](https://developer.hashicorp.com/terraform/policy) to the Policy Engines section, next to Sentinel.

HashiCorp announced it on 2026-07-16. HCL-based policy-as-code framework, evaluated at three points in an HCP Terraform run (provider and module install, plan, apply), plus a local CLI for testing policies before commit. Public beta.

## Curation notes

- **Links to docs, not the announcement blog post.** The curation policy rejects vendor blog posts, and every other tool entry links to product docs or the project itself.
- **Beta disclosed** in the description so readers do not adopt it unaware.
- **`💲` only**, matching the sibling Sentinel entry. Policy enforcement tier availability is not published on the HCP Terraform pricing page, so `🆓` is not claimable.

## Second change

`readme.md:226` listed only Sentinel and OPA as HCP Terraform's native policy frameworks. Now lists all three.

## Not included

- No Learning Resources entry for the announcement blog post (vendor blog post gate).
- No TOC change, no section added or renamed.
- No entry for `hashicorp/agent-skills` — agent skill collection, not IaC compliance tooling.

## Verification

- `lychee` and `awesome-lint` pre-commit hooks passed.
- Docs URL fetched live, returns 200.
- URL appears once in the list, no duplicate.